### PR TITLE
fix script engine is null

### DIFF
--- a/src/main/java/net/swordie/ms/client/character/skills/info/SkillInfo.java
+++ b/src/main/java/net/swordie/ms/client/character/skills/info/SkillInfo.java
@@ -42,7 +42,7 @@ public class SkillInfo {
     private Map<Integer, Integer> reqSkills = new HashMap<>();
     private boolean notCooltimeReset;
     private boolean notIncBuffDuration;
-    private static ScriptEngine engine = new ScriptEngineManager().getEngineByName("JavaScript");
+    private static ScriptEngine engine = new ScriptEngineManager(null).getEngineByName("JavaScript");
     private boolean psd;
     private Set<Integer> addAttackSkills = new HashSet<>();
     private List<HashMap<Integer, Integer>> extraSkillInfo = new ArrayList<>();


### PR DESCRIPTION
When i added skill point, the server logged an error and crashed the client:
`Cannot invoke "javax.script.ScriptEngine.eval (string) " because "net.swordie.ms.client.character.skills.info.SkillInfo.engine" is null`
Pass null to the ScriptEngineManager constructor works for me.
